### PR TITLE
Add Kyle Cordes's clojure posts correctly this time

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -625,7 +625,7 @@ name = Andrew Gwozdziewycz
 [http://clojuredocs.wordpress.com/category/clojure/feed/]
 name = ClojureDocs
 
-[http://kylecordes.com/tag/clojure]
+[http://kylecordes.com/tag/clojure/feed]
 name = Kyle Cordes
 
 [http://blog.bensmann.com/tag/clojure/feed]


### PR DESCRIPTION
Last time, I miscopied the feed URL. Ooops.
