### PR TITLE
Added my clojure blog posts to the Clojure/config.ini file

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1160,3 +1160,6 @@ name = Peteris Erins
 # http://eddology.com/
 [http://pipes.yahoo.com/pipes/pipe.run?_id=6462cfea7cc38fbbfd8ffe83c6e5a79d&_render=rss]
 name = Edd Dumbill
+
+[http://blog.jr0cket.co.uk/search/label/PlanetClojure]
+name = John Stevenson


### PR DESCRIPTION
Updated Clojure/config.ini to inlcude URL and name of my blog at the end of the file.  Only articles tagged with PlanetClojure will be pulled from my blog using the supplied URL. 
