### PR TITLE
please add commit for blog.milehighcode.com

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1145,3 +1145,7 @@ name = Yoko Harada
 # http://www.pgrs.net/
 [http://pipes.yahoo.com/pipes/pipe.run?_id=21c2a96208e329bcffb14a3d4c4f6002&_render=rss]
 name = Paul Gross
+
+# http://blog.milehighcode.com
+[http://blog.milehighcode.com/feeds/posts/default]
+name = Mile High Code


### PR DESCRIPTION
Hi,

http://blog.milehighcode.com is a development blog primarily focused on clojure. 

Thanks for adding this, what a neat concept (planet.clojure)
