### PR TITLE
Add http-kit.org's blog atom

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -76,7 +76,7 @@ faceheight = 85
 # Any other section defines a feed to subscribe to.  The section title
 # (in the []s) is the URI of the feed itself.  A section can also be
 # have any of the following options:
-# 
+#
 # name: Name of the feed (defaults to the title found in the feed)
 #
 # Additionally any other option placed here will be available in
@@ -136,7 +136,7 @@ name = Shantanu Kumar
 name = On Clojure
 
 [http://blog.higher-order.net/category/clojure/feed/]
-name = Karl Krukow 
+name = Karl Krukow
 
 [http://timothypratley.blogspot.com/feeds/posts/default]
 name = Timothy Pratley
@@ -266,7 +266,7 @@ name = David Rupp
 name = Hugo Duncan
 
 [http://formpluslogic.blogspot.com/feeds/posts/default]
-name = Form plus Logic 
+name = Form plus Logic
 
 [http://blog.danieljanus.pl/blog/categories/clojure/atom.xml]
 name = Daniel Janus
@@ -299,7 +299,7 @@ name = Ethan Fast
 [http://pipes.yahoo.com/pipes/pipe.run?_id=b940a51bb4440a4817478df38a4bfc12&_render=rss]
 name = Mark McGranaghan
 
-# http://ideolalia.com/ 
+# http://ideolalia.com/
 [http://pipes.yahoo.com/pipes/pipe.run?_id=2859b085bb0148ae9095e616a6de354f&_render=rss]
 name = Zach Tellman
 
@@ -336,7 +336,7 @@ name = Mark Reid
 
 # http://www.deepbluelambda.org
 [http://pipes.yahoo.com/pipes/pipe.run?_id=6aed67e98c4180d0ce97a3bfa542b803&_render=rss]
-name = Deep Blue Lambda 
+name = Deep Blue Lambda
 
 #[http://www.haltingproblem.net/weblog/tags/tech/clojure/feed/]
 [http://latebound.posterous.com/rss.xml?tag=clojure]
@@ -827,7 +827,7 @@ name = Rasmus Svensson
 name = Carson Cheng
 
 [http://kuriqoo.blogspot.com/feeds/posts/default/-/clojure]
-name = Christophe Verré 
+name = Christophe Verré
 
 # http://www.adrianmouat.com/bit-bucket/
 [http://pipes.yahoo.com/pipes/pipe.run?_id=03725c0c7484f6f0757ab3e7942ef873&_render=rss]
@@ -992,7 +992,7 @@ name = Holger Durer
 name = Ralph Moritz
 
 [http://nounsvsverbs.blogspot.com/feeds/posts/default/-/clojure]
-name = Daniel Glauser 
+name = Daniel Glauser
 
 [http://www.markhneedham.com/blog/category/clojure/feed/]
 name = Mark Needham
@@ -1161,7 +1161,7 @@ name = Paul Gross
 name = Ben Hughes
 
 # http://peteriserins.com/
-[http://pipes.yahoo.com/pipes/pipe.run?_id=b91b982d225d86cda9278274c6f709d2&_render=rss] 
+[http://pipes.yahoo.com/pipes/pipe.run?_id=b91b982d225d86cda9278274c6f709d2&_render=rss]
 name = Peteris Erins
 
 # http://eddology.com/
@@ -1625,7 +1625,7 @@ name = John Jacobsen
 name = Amsterdam Clojurians Meetup
 
 [http://internistic.blogspot.ca/feeds/posts/default/-/clojure]
-name = Paul Umbers 
+name = Paul Umbers
 
 [http://elhumidor.blogspot.de//feeds/posts/default/-/clojure]
 name = John Hume
@@ -1645,7 +1645,7 @@ name = Thomas Schank
 
 # http://blog.brandonbloom.name/
 [http://pipes.yahoo.com/pipes/pipe.run?_id=0e909306e700dd468e7ad20f9a412296&_render=rss]
-name = Brandon Bloom 
+name = Brandon Bloom
 
 [http://loganis-data-science.blogspot.com/feeds/posts/default/-/Clojure]
 name = Arnold Matyasi
@@ -1714,3 +1714,6 @@ name = August Lilleaas
 [http://pipes.yahoo.com/pipes/pipe.run?_id=2f3f203455a6ed01cce64870008438b6&_render=rss]
 name = Michael Hanson
 
+# http://http-kit.org/
+[http://http-kit.org/atom.xml]
+name = HTTP Kit


### PR DESCRIPTION
Emacs remove the trailing whitespace.  If you are not happy about this, I can edit the config.init with vim and send another PR.
