### PR TITLE
Add Clojure Feed for http://gphil.net

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1815,7 +1815,7 @@ name = Parallel Universe blog
 name = Marian Schubert
 
 [http://fbmnds.blogspot.com/feeds/posts/default]
-name = Friedrich Boeckh 
+name = Friedrich Boeckh
 
 [http://agnosticdevs.com/category/clojure/feed/]
 name = AgnosticDevs
@@ -1886,3 +1886,6 @@ name = Bluemont Labs
 # http://blog.goodstuff.im/
 [http://pipes.yahoo.com/pipes/pipe.run?_id=4396759a366a450ed316ff9dec8e96ca&_render=rss]
 name = David Pollak
+
+[http://gphil.net/tags/clojure.xml]
+name = Greg Phillips


### PR DESCRIPTION
I'd like to add the feed for the Clojure posts on my blog to Planet Clojure.
