### PR TITLE
added mattyw.net blog

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1394,6 +1394,9 @@ name = Flying Machine Studios
 [http://mattyjwilliams.blogspot.co.uk/feeds/posts/default/-/clojure]
 name = Matty Williams
 
+[http://blog.mattyw.net/blog/categories/clojure/atom.xml]
+name = Matt Williams
+
 [http://www.andrewhjon.es/rss.xml?tag=clojure]
 name = Andrew Jones
 


### PR DESCRIPTION
This replaces my old blog (the Matty Williams url above the new one) I wasn't sure if I should delete it and replace it with the new one, or just add the new one like this. The old blog is still active so I thought I'd leave it like this.
