### PR TITLE
Add Bright North's "Lab" blog (pulling only the posts tagged "clojure")

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -2627,6 +2627,11 @@ name = Clojure/GSoC
 name = Jeff Fowler
 filters = nopipeerrors.py
 
+# Bright North's "Lab" blog (Clojure tag)
+[http://lab.brightnorth.co.uk/tag/clojure/rss/]
+name=Bright North Lab
+
+
 # TODO: http://amitksaha.wordpress.com/
 # TODO: http://blog.hashobject.com/make-static-site-with-clojure-and-host-on-amazon/
 # TODO: http://beandipper.github.io/


### PR DESCRIPTION
Bright North uses Clojure as its' main development language. 
We've recently started blogging from the development team, and have quite a lot of stuff we want to talk about (and we hope our existing content on integration testing Clojure webapps with Midje is useful too)
