### PR TITLE
Add feed for Bruno Vecchi

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -2671,6 +2671,9 @@ name = Alexander Turok
 [http://lab.brightnorth.co.uk/tag/clojure/rss/]
 name = Bright North Lab
 
+[http://brunov.org/feed-clojure.xml]
+name = Bruno Vecchi
+
 # TODO: http://amitksaha.wordpress.com/
 # TODO: http://blog.hashobject.com/make-static-site-with-clojure-and-host-on-amazon/
 # TODO: http://beandipper.github.io/


### PR DESCRIPTION
Hi! I'd like to have my blog added to Planet Clojure.

[Feed link](http://brunov.org/feed-clojure.xml) (only those posts tagged as Clojure will show up)
[Blog link](http://brunov.org)
