### PR TITLE
Update Prismatic blog URL

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1391,7 +1391,7 @@ name = Dustin Getz
 filters = nopipeerrors.py
 
 # http://blog.getprismatic.com/blog/
-[http://pipes.yahoo.com/pipes/pipe.run?_id=70e7bf2bcf7efd6c56d483cfa7c380ed&_render=rss]
+[http://pipes.yahoo.com/pipes/pipe.run?_id=9d4549e4c857804ed778e991a66b4be0&_render=rss]
 name = Prismatic
 filters = nopipeerrors.py
 


### PR DESCRIPTION
Prismatic's blog URL changed and the Yahoo pipe referred to the old URL. This
changes the pipe to an updated version.
