### PR TITLE
Add uSwitch Tech Blog.

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -2722,6 +2722,9 @@ name = Clojure Budapest meetup videos
 name = Mary Rose Cook
 filters = nopipeerrors.py
 
+[http://www.uswitch.com/tech/tag-clojure.articles.xml]
+name = uSwitch Tech Blog
+
 # TODO: http://amitksaha.wordpress.com/
 # TODO: http://blog.hashobject.com/make-static-site-with-clojure-and-host-on-amazon/
 # TODO: http://beandipper.github.io/


### PR DESCRIPTION
I've added the Clojure part of the uSwitch Tech Blog. The feed will only contain blog posts tagged with Clojure.
