### PR TITLE
Replace codethat.wordpress.com for bytopia.org

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1151,8 +1151,8 @@ filters = nopipeerrors.py
 name = fronx
 filters = nopipeerrors.py
 
-[http://codethat.wordpress.com/category/clojure/feed/]
-name = Code that
+[http://www.bytopia.org/tags/clojure/rss-feed]
+name = Alex Yakushev
 
 # http://www.philcalcado.com/tags/clojure/
 [http://pipes.yahoo.com/pipes/pipe.run?_id=2ac9f144f88726c30c12cb00c073f765&_render=rss]


### PR DESCRIPTION
My old blog codethat.wordpress.com is deprecated now (as stated here: https://codethat.wordpress.com/2012/12/14/this-blog-is-marked-as-deprecated/). Instead I added my new blog.
