### PR TITLE
Updated doppioslash's blog rss url

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -2034,7 +2034,7 @@ name = Vishal Sakaria
 
 # http://blog.doppioslash.com/
 # [http://pipes.yahoo.com/pipes/pipe.run?_id=e1c48889ca8970957c5c8e1e53d6e60f&_render=rss]
-[http://blog.doppioslash.com/blog/categories/clojure/atom.xml]
+[http://blog.doppioslash.com/tag/clojure/rss/]
 name = Claudia Doppioslash
 
 # http://www.1729.org.uk/tags/clojure


### PR DESCRIPTION
I've switched to Ghost from Octopress, so my rss feed for the Clojure category has a new url.
