### PR TITLE
Updated The BHW Group URL to match new tag url structure.

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -2818,7 +2818,7 @@ name = Greg Hawkins
 name = Robert Stuttaford
 filters = nopipeerrors.py
 
-[http://www.thebhwgroup.com/blog/tag/clojure/feed/]
+[https://thebhwgroup.com/tags/clojure]
 name = The BHW Group
 
 # http://www.marcoyuen.com/


### PR DESCRIPTION
We did a site redesign and some of our URLs changed. Just updating the config so that the URL is correct and no longer 404s.