### PR TITLE
Remove old blog, point feed to new location

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -419,8 +419,8 @@ name = Glen Stampoultzis
 [http://toinfinity.wordpress.com/category/coding/clojure/feed/]
 name = Infinity: Easier Than You Think. Infinitely.
 
-[http://joost.zeekat.nl/category/clojure/feed/]
-name = code.h(oe)kje
+[http://zeekat.nl/news/tag/clojure/index.rss]
+name = Zeekat.nl news for clojure
 
 [http://tech.puredanger.com/?cat=133&feed=rss2]
 name = Alex Miller


### PR DESCRIPTION
I'm removing my old wordpress blog and merged the content into the main
site for zeekat.nl. New articles about clojure will be posted there.