### PR TITLE
Adding Kontor tech blog

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3441,6 +3441,10 @@ name = Arachne Framework
 [https://jobs.braveclojure.com/jobs.rss]
 name = Brave Clojure Jobs
 
+[https://tech.kontor.com/feed]
+name = Kontor Engineering Blog
+filter = (clojure|Clojure|\(def |\(defn-? )
+
 # http://blog.klipse.tech/clojure/2016/04/07/ifn.html - recheck. It's included already,
 # but redirected from another blog
 


### PR DESCRIPTION
Hi! I wanted to add [my company's engineering blog](https://tech.kontor.com/) to Planet Clojure. Hopefully the filters work, as Medium doesn't have a lot of options for RSS filters and we have various non-Clojure content that pops up there from time to time.