### PR TITLE
Change Clojure Gazette Feed link

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1457,7 +1457,7 @@ name = Xavier Shay
 name = Brian Taylor
 filter = (clojure|Clojure|\(def |\(defn-? )
 
-[http://us4.campaign-archive2.com/feed?u=a33b5228d1b5bf2e0c68a83f4&id=4c2b86e9f4]
+[https://clojuregazette.com/feed/]
 name = Clojure Gazette
 
 [http://paralambda.org/tag/clojure/feed/]


### PR DESCRIPTION
I've moved to a new site. This is the better feed.