### PR TITLE
Add bevuta IT GmbH blog

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3471,6 +3471,9 @@ name = Real World Clojure
 name = Metosin
 filter = (clojure|Clojure|\(def |\(defn-? )
 
+[https://www.bevuta.com/en/blog/tags/clojure.atom]
+name = bevuta IT
+
 # http://blog.klipse.tech/clojure/2016/04/07/ifn.html - recheck. It's included already,
 # but redirected from another blog
 


### PR DESCRIPTION
This feed only provides posts tagged with `clojure` so it doesn't require a filter.