### PR TITLE
Add Lambda Island blog + free episodes

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3474,6 +3474,12 @@ filter = (clojure|Clojure|\(def |\(defn-? )
 [https://www.bevuta.com/en/blog/tags/clojure.atom]
 name = bevuta IT
 
+[https://lambdaisland.com/feeds/blog.atom]
+name = Lambda Island Blog
+
+[https://lambdaisland.com/feeds/freebies.atom]
+name = Lambda Island Freebies
+
 # http://blog.klipse.tech/clojure/2016/04/07/ifn.html - recheck. It's included already,
 # but redirected from another blog
 


### PR DESCRIPTION
The first feed is for the blog, which is 100% Clojure related content.

The second feed contains all the free screencasts.