### PR TITLE
Remove broken PrecursorApp feed

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -2900,9 +2900,9 @@ filter = (clojure|Clojure|\(def |\(defn-? )
 [http://garajeando.blogspot.com.es/feeds/posts/default/-/Clojure]
 name = Garajeando
 
-[https://precursorapp.com/blog.rss]
-name = PrecursorApp
-filter = (clojure|Clojure|\(def |\(defn-? )
+# [https://precursorapp.com/blog.rss]
+# name = PrecursorApp
+# filter = (clojure|Clojure|\(def |\(defn-? )
 
 [http://code-and-cocktails.herokuapp.com/blog/categories/clojure/feed/]
 name = Mark Simpson


### PR DESCRIPTION
PrecursorApp feed (https://precursorapp.com/blog.rss) returns current time `pubDate` for their latest blog entry, making it re-appear in the feed repeatedly.

I've asked them to fix it [1], but in the meantime to stop this annoyance their feed could be removed.

[1] https://twitter.com/ernestas/status/798563820209774592