### PR TITLE
added bigsolutions.io blog

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3557,6 +3557,9 @@ name = Przemysław Wojnowski
 name = Mooi Studios
 filter = (clojure|Clojure|\(def |\(defn-? )
 
+[https://bigsolutions.io/category/clojure/feed/atom/]
+name = Big Solutions
+
 #[]
 #name = 
 #filter = (clojure|Clojure|\(def |\(defn-? )


### PR DESCRIPTION
We post about Clojure as well as other topics. All Clojure related posts are in the category called "clojure". so I limited the feed url to that.