### PR TITLE
Moved my site to PurelyFunctional.tv domain

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -1457,8 +1457,8 @@ name = Xavier Shay
 name = Brian Taylor
 filter = (clojure|Clojure|\(def |\(defn-? )
 
-[https://clojuregazette.com/feed/]
-name = Clojure Gazette
+[https://purelyfunctional.tv/tag/clojure/feed/]
+name = PurelyFunctional.tv Clojure articles
 
 [http://paralambda.org/tag/clojure/feed/]
 name = Alexander Kahl


### PR DESCRIPTION
Clojure Gazette now redirects to PurelyFunctional.tv, but the feed was not set up. Now only stuff with the Clojure tag will go through.

Rock on!
Eric