### PR TITLE
Add Clojure tag of Klarna Engineering blog

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3695,6 +3695,9 @@ name = ClojureScript News
 [http://increasinglyfunctional.com/tag/clojure.xml]
 name = Increasingly Functional - Joshua Miller
 
+[https://engineering.klarna.com/feed/tagged/clojure]
+name = Klarna Engineering Blog
+
 #[]
 #name = 
 #filter = (clojure|Clojure|\(def |\(defn-? )


### PR DESCRIPTION
Klarna is a Stockholm-based company that uses Clojure in production and has sponsored a ClojureBridge workshop. We have occasional posts on Clojure on our engineering blog.

This PR adds posts tagged as Clojure from the blog.