### PR TITLE
Add Clojure SYNC feed

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3728,6 +3728,9 @@ filter = (clojure|Clojure|\(def |\(defn-? )
 name = Pyroclast
 filter = (clojure|Clojure|\(def |\(defn-? )
 
+[https://clojuresync.com/feed/]
+name = Clojure SYNC News
+
 #[]
 #name = 
 #filter = (clojure|Clojure|\(def |\(defn-? )


### PR DESCRIPTION
Clojure SYNC is a new Clojure conference happening in New Orleans in February 2018.