### PR TITLE
Added modulolotus.net

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3813,6 +3813,9 @@ filter = (clojure|Clojure|\(def |\(defn-? )
 name = Chris Betz
 filter = (clojure|Clojure|clojurescript|ClojureScript)
 
+[http://modulolotus.net/feed.xml]
+name = Modulo Lotus
+filter = (clojure|Clojure|clojurescript|ClojureScript|\(def |\(defn-? )
 
 #[]
 #name =


### PR DESCRIPTION
I used the `filter` option on the main feed that everyone else was using, but if you need a more specific feed, I can switch it to http://modulolotus.net/clojure.xml.