### PR TITLE
Update config.ini

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3777,7 +3777,7 @@ name = Zalando Tech Blog
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = ZalandoTech
 
-[http://sprungcanary.net/atom_clojure.xml]
+[http://sprungcanary.net/clojure.xml]
 name = Bret Young
 twitter = sprungcanary
 


### PR DESCRIPTION
I changed my blog to be based on Cryogen which caused the clojure tagged feed name to change.