### PR TITLE
Changed Kari Marttila's blog from Medium to Github Pages

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -4801,9 +4801,9 @@ name = Level Up Coding
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = gitconnected
 
-[https://medium.com/feed/@kari.marttila]
+[https://www.karimarttila.fi/feed/clojure.xml]
 name = Kari Marttila
-filter = (clojure|Clojure|\(def |\(defn-? )
+#filter = (clojure|Clojure|\(def |\(defn-? )
 
 [https://medium.com/feed/@sfyire]
 name = Adrian Smith


### PR DESCRIPTION
Changed Kari Marttila's blog from Medium to Github Pages.
Rationale: Github Pages provides a lot better visualization e.g. for code blocks.
I created a clojure category feed as requested.