### PR TITLE
Add Crux Blog with Clojure filter

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3388,6 +3388,11 @@ name = The JUXT Blog
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = juxtpro
 
+[https://opencrux.com/_/blog/crux-feed.rss]
+name = Crux Blog
+filter = (clojure|Clojure|\(def |\(defn-? )
+twitter = juxtpro
+
 [http://blog.wagjo.com/feed.xml]
 name = Jozef Wagner
 filter = (clojure|Clojure|\(def |\(defn-? )


### PR DESCRIPTION
Hello, Planet Clojure!

This PR adds the Crux Blog with a Clojure filter. We do have a hard category for Clojure posts as well, but it seems Venus can't parse RSS categories and filter on them explicitly? Let me know if you would prefer that we create an entirely separate, Clojure-only feed based on our `clojure` category in the blog.

Thanks!
-steven
