### PR TITLE
Update klipse configuration

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3985,7 +3985,7 @@ twitter = upgradingdave
 
 [http://blog.klipse.tech/feed.xml]
 name = Yehonathan Sharvit
-filter = (clojure|Clojure|\(def |\(defn-? )
+filter = (clojure|Clojure|dop|\(def |\(defn-? )
 twitter = viebel
 
 [http://overtone-recipes.github.io/feed.xml]
@@ -4182,10 +4182,6 @@ twitter = dottedmag
 name = Deps
 twitter = deps_app
 
-[https://read.klipse.tech/rss/]
-name = Yehonathan Sharvit
-filter = (clojure|Clojure|\(def |\(defn-? )
-twitter = viebel
 
 [https://medium.com/feed/@roman01la]
 name = Roman Liutikov


### PR DESCRIPTION
- Add dop to regex (stands for Data-Oriented programming)
- Remove read.klipse.tech (the site not longer exists)