### PR TITLE
Switch to Metosin clojure.xml feed

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -4068,9 +4068,8 @@ twitter = owickstrom
 name = Real World Clojure
 twitter = pjstadig
 
-[https://www.metosin.fi/atom.xml]
+[https://www.metosin.fi/clojure.xml]
 name = Metosin
-filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = metosin
 
 [https://www.bevuta.com/en/blog/tags/clojure.atom]


### PR DESCRIPTION
I've added a separate Clojure feed based on post metadata, which should better filter out non-Clojure posts.