### PR TITLE
Use clojure and clojurescripts specific feeds

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -5199,9 +5199,12 @@ name = Clojure Arcana
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = clojurearcana
 
-[https://andreyorst.gitlab.io/feed.xml]
+[https://andreyorst.gitlab.io/tags/clojure/feed.xml]
 name = Andrey Listopadov
-filter = (clojure|Clojure|\(def |\(defn-? )
+twitter = andreyorst
+
+[https://andreyorst.gitlab.io/tags/clojurescript/feed.xml]
+name = Andrey Listopadov
 twitter = andreyorst
 
 [https://carl.duevel.online/tags/clojure/index.xml]


### PR DESCRIPTION
I've figured out why my feeds for tags contained the same information as the base feed and fixed that. So, to avoid false positives that happen, when I write posts about Fennel, in which I often reference Clojure, I've changed the feed link to two links for each feed.