### PR TITLE
Removed personal Twitter account, added company blog

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -4781,7 +4781,6 @@ twitter = drewverlee
 [https://javahippie.net/feed.xml]
 name = The Java Hippie (Tim Zöller)
 filter = (clojure|Clojure|\(def |\(defn-? )
-twitter = javahippie
 
 [https://matthewdowney.github.io/atom.xml]
 name = Matthew Downey
@@ -5659,6 +5658,11 @@ filter = (clojure|Clojure|\(def |\(defn-? )
 name =  Greg Rynkowski
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = rynkowsg
+
+[https://lambdaschmiede.com/en/blog/feed.xml]
+name = lambdaschmiede GmbH
+filter = (clojure|Clojure|\(def |\(defn-? )
+
 
 #[]
 #name =


### PR DESCRIPTION
Hi there,

I removed the link to my (no longer existing) Twitter Account for my personal blog, and added our technical company blog which will will also contain Clojure postings.

If you'd like to have those two changes separately, of if you feel uneasey about adding the blog on our company website (will stay free from advertising and marketing, purely technial), then I'd be able to separate the changes.