### PR TITLE
fix: add clojureplanet specific feed

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -3414,9 +3414,9 @@ twitter = verdammelt
 name = The BitTorrent Engineering Blog
 twitter = bittorrent
 
-[https://juxt.pro/blog/rss.xml?category=clojure&since=2016-03-13]
+[https://juxt.pro/clojureplanet.xml]
 name = The JUXT Blog
-filter = (clojure|Clojure|\(def |\(defn-? )
+#filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = juxtpro
 
 [https://xtdb.com/blog.xml]


### PR DESCRIPTION
Hey, I added a feed with all our clojure blogs in one place.
That should be slightly better than having a 404 page 😅 