### PR TITLE
config: updated feed url for Practical.li blog

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -4696,7 +4696,7 @@ name = Erik Assum
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = slipset
 
-[https://practical.li/blog/feed.xml]
+[https://practical.li/blog/feed_rss_created.xml]
 name = Practicalli
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = practical_li


### PR DESCRIPTION
Blog migrated to Material for MkDocs and has a new URL for the RSS feed.