### PR TITLE
config: practicalli blog feed moved again (sorry)

### DIFF
--- a/clojure/config.ini
+++ b/clojure/config.ini
@@ -4696,7 +4696,7 @@ name = Erik Assum
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = slipset
 
-[https://practical.li/blog/feed_rss_created.xml]
+[https://practical.li/feed_rss_created.xml]
 name = Practicalli
 filter = (clojure|Clojure|\(def |\(defn-? )
 twitter = practical_li


### PR DESCRIPTION
Practicalli home page and blog has merged and unfortunately it wasnt possible to set the location of the feed to the same location as the updated blog.

Sorry for the inconvenience.